### PR TITLE
Iox 27 rename pod marker to shm send

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: cache-${{ runner.os }}-toolchain-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/build.rs') }}
+        key: cache-1-${{ runner.os }}-toolchain-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/build.rs') }}
     - name: Install dependencies
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
@@ -93,7 +93,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: coverage-llvm-tools-preview-cache-${{ runner.os }}-toolchain-nightly-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/build.rs') }}
+        key: coverage-llvm-tools-preview-cache-1-${{ runner.os }}-toolchain-nightly-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/build.rs') }}
     - name: Install dependencies
       run: |
         sudo apt update

--- a/examples/publisher_simple.rs
+++ b/examples/publisher_simple.rs
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: © Contributors to the iceoryx-rs project
 // SPDX-FileContributor: Mathias Kraus
 
-use iceoryx_rs::pb::{PublisherBuilder, POD};
+use iceoryx_rs::marker::ShmSend;
+use iceoryx_rs::pb::PublisherBuilder;
 use iceoryx_rs::Runtime;
 
 use std::error::Error;
@@ -14,7 +15,7 @@ struct Counter {
     counter: u32,
 }
 
-unsafe impl POD for Counter {}
+unsafe impl ShmSend for Counter {}
 
 fn main() -> Result<(), Box<dyn Error>> {
     Runtime::init("publisher_simple");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod queue_policy;
 mod runtime;
 
 pub mod introspection;
+pub mod marker;
 pub mod pb;
 pub mod sb;
 

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -16,7 +16,8 @@
 /// In general, types that could implement the Copy trait fulfill these requirements.
 pub unsafe trait ShmSend {}
 
-// TODO more impls
+unsafe impl ShmSend for bool {}
+
 unsafe impl ShmSend for i8 {}
 unsafe impl ShmSend for u8 {}
 unsafe impl ShmSend for i16 {}
@@ -25,7 +26,82 @@ unsafe impl ShmSend for i32 {}
 unsafe impl ShmSend for u32 {}
 unsafe impl ShmSend for i64 {}
 unsafe impl ShmSend for u64 {}
+unsafe impl ShmSend for i128 {}
+unsafe impl ShmSend for u128 {}
 unsafe impl ShmSend for f32 {}
 unsafe impl ShmSend for f64 {}
 unsafe impl ShmSend for isize {}
 unsafe impl ShmSend for usize {}
+
+unsafe impl ShmSend for char {}
+
+unsafe impl<T: ShmSend, const N: usize> ShmSend for [T; N] {}
+
+unsafe impl<T: ShmSend> ShmSend for Option<T> {}
+
+unsafe impl<T: ShmSend, E: ShmSend> ShmSend for Result<T, E> {}
+
+// TODO create macro to impl ShmSend for tuples
+unsafe impl<T1, T2> ShmSend for (T1, T2)
+where
+    T1: ShmSend,
+    T2: ShmSend,
+{
+}
+unsafe impl<T1, T2, T3> ShmSend for (T1, T2, T3)
+where
+    T1: ShmSend,
+    T2: ShmSend,
+    T3: ShmSend,
+{
+}
+unsafe impl<T1, T2, T3, T4> ShmSend for (T1, T2, T3, T4)
+where
+    T1: ShmSend,
+    T2: ShmSend,
+    T3: ShmSend,
+    T4: ShmSend,
+{
+}
+unsafe impl<T1, T2, T3, T4, T5> ShmSend for (T1, T2, T3, T4, T5)
+where
+    T1: ShmSend,
+    T2: ShmSend,
+    T3: ShmSend,
+    T4: ShmSend,
+    T5: ShmSend,
+{
+}
+unsafe impl<T1, T2, T3, T4, T5, T6> ShmSend for (T1, T2, T3, T4, T5, T6)
+where
+    T1: ShmSend,
+    T2: ShmSend,
+    T3: ShmSend,
+    T4: ShmSend,
+    T5: ShmSend,
+    T6: ShmSend,
+{
+}
+unsafe impl<T1, T2, T3, T4, T5, T6, T7> ShmSend for (T1, T2, T3, T4, T5, T6, T7)
+where
+    T1: ShmSend,
+    T2: ShmSend,
+    T3: ShmSend,
+    T4: ShmSend,
+    T5: ShmSend,
+    T6: ShmSend,
+    T7: ShmSend,
+{
+}
+unsafe impl<T1, T2, T3, T4, T5, T6, T7, T8> ShmSend for (T1, T2, T3, T4, T5, T6, T7, T8)
+where
+    T1: ShmSend,
+    T2: ShmSend,
+    T3: ShmSend,
+    T4: ShmSend,
+    T5: ShmSend,
+    T6: ShmSend,
+    T7: ShmSend,
+    T8: ShmSend,
+{
+}

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © Contributors to the iceoryx-rs project
+// SPDX-FileContributor: Mathias Kraus
+
+/// # Safety
+///
+/// This is a marker trait for types that can be transferred via shared memory.
+/// The types must satisfy the following conditions:
+/// - no heap is used
+/// - the data structure is entirely contained in the shared memory - no pointers
+///   to process local memory, no references to process local constructs, no dynamic allocators
+/// - the data structure has to be relocatable and therefore must not internally
+///   use pointers/references
+/// - the type must not impl Drop; drop will not be called when the memory is released since the
+///   memory might be located in a shm segment without write access
+/// In general, types that could implement the Copy trait fulfill these requirements.
+pub unsafe trait ShmSend {}
+
+// TODO more impls
+unsafe impl ShmSend for i8 {}
+unsafe impl ShmSend for u8 {}
+unsafe impl ShmSend for i16 {}
+unsafe impl ShmSend for u16 {}
+unsafe impl ShmSend for i32 {}
+unsafe impl ShmSend for u32 {}
+unsafe impl ShmSend for i64 {}
+unsafe impl ShmSend for u64 {}
+unsafe impl ShmSend for f32 {}
+unsafe impl ShmSend for f64 {}
+unsafe impl ShmSend for isize {}
+unsafe impl ShmSend for usize {}

--- a/src/pb/mod.rs
+++ b/src/pb/mod.rs
@@ -8,6 +8,5 @@ mod publisher_options;
 mod sample;
 
 pub use publisher::{InactivePublisher, Publisher, PublisherBuilder};
-pub use sample::POD;
 
 use publisher_options::PublisherOptions;

--- a/src/pb/publisher.rs
+++ b/src/pb/publisher.rs
@@ -2,13 +2,14 @@
 // SPDX-FileCopyrightText: © Contributors to the iceoryx-rs project
 // SPDX-FileContributor: Mathias Kraus
 
-use super::{ffi::Publisher as FfiPublisher, sample::SampleMut, PublisherOptions, POD};
+use super::{ffi::Publisher as FfiPublisher, sample::SampleMut, PublisherOptions};
+use crate::marker::ShmSend;
 use crate::ConsumerTooSlowPolicy;
 use crate::IceoryxError;
 
 use std::marker::PhantomData;
 
-pub struct PublisherBuilder<'a, T: POD> {
+pub struct PublisherBuilder<'a, T: ShmSend> {
     service: &'a str,
     instance: &'a str,
     event: &'a str,
@@ -16,7 +17,7 @@ pub struct PublisherBuilder<'a, T: POD> {
     phantom: PhantomData<T>,
 }
 
-impl<'a, T: POD> PublisherBuilder<'a, T> {
+impl<'a, T: ShmSend> PublisherBuilder<'a, T> {
     pub fn new(service: &'a str, instance: &'a str, event: &'a str) -> Self {
         Self {
             service,
@@ -68,12 +69,12 @@ impl<'a, T: POD> PublisherBuilder<'a, T> {
     }
 }
 
-pub struct InactivePublisher<T: POD> {
+pub struct InactivePublisher<T: ShmSend> {
     ffi_pub: Box<FfiPublisher>,
     phantom: PhantomData<T>,
 }
 
-impl<T: POD> InactivePublisher<T> {
+impl<T: ShmSend> InactivePublisher<T> {
     fn new_from_publisher(publisher: Publisher<T>) -> Self {
         Self {
             ffi_pub: publisher.ffi_pub,
@@ -87,12 +88,12 @@ impl<T: POD> InactivePublisher<T> {
     }
 }
 
-pub struct Publisher<T: POD> {
+pub struct Publisher<T: ShmSend> {
     ffi_pub: Box<FfiPublisher>,
     phantom: PhantomData<T>,
 }
 
-impl<T: POD> Publisher<T> {
+impl<T: ShmSend> Publisher<T> {
     fn new_from_inactive_publisher(publisher: InactivePublisher<T>) -> Self {
         Self {
             ffi_pub: publisher.ffi_pub,

--- a/src/pb/sample.rs
+++ b/src/pb/sample.rs
@@ -3,40 +3,16 @@
 // SPDX-FileContributor: Mathias Kraus
 
 use super::Publisher;
+use crate::marker::ShmSend;
 
 use std::ops::{Deref, DerefMut};
 
-/// # Safety
-///
-/// This is a marker trait for types that can be transferred via shared memory.
-/// The types must satisfy the following conditions:
-/// - no heap is used
-/// - the data structure is entirely contained in the shared memory - no pointers
-///   to process local memory, no references to process local constructs, no dynamic allocators
-/// - the data structure has to be relocatable and therefore must not internally
-///   use pointers/references
-/// In general, types that could implement the Copy trait fulfill these requirements.
-pub unsafe trait POD {}
-// TODO more impls
-unsafe impl POD for i8 {}
-unsafe impl POD for u8 {}
-unsafe impl POD for i16 {}
-unsafe impl POD for u16 {}
-unsafe impl POD for i32 {}
-unsafe impl POD for u32 {}
-unsafe impl POD for i64 {}
-unsafe impl POD for u64 {}
-unsafe impl POD for f32 {}
-unsafe impl POD for f64 {}
-unsafe impl POD for isize {}
-unsafe impl POD for usize {}
-
-pub struct SampleMut<'a, T: POD> {
+pub struct SampleMut<'a, T: ShmSend> {
     pub(super) data: Option<Box<T>>,
     pub(super) service: &'a Publisher<T>,
 }
 
-impl<'a, T: POD> Deref for SampleMut<'a, T> {
+impl<'a, T: ShmSend> Deref for SampleMut<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -44,13 +20,13 @@ impl<'a, T: POD> Deref for SampleMut<'a, T> {
     }
 }
 
-impl<'a, T: POD> DerefMut for SampleMut<'a, T> {
+impl<'a, T: ShmSend> DerefMut for SampleMut<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.data.as_mut().expect("valid sample")
     }
 }
 
-impl<'a, T: POD> Drop for SampleMut<'a, T> {
+impl<'a, T: ShmSend> Drop for SampleMut<'a, T> {
     fn drop(&mut self) {
         if let Some(chunk) = self.data.take() {
             self.service.release_chunk(chunk);

--- a/src/tests/basic_pub_sub.rs
+++ b/src/tests/basic_pub_sub.rs
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: © Contributors to the iceoryx-rs project
 // SPDX-FileContributor: Mathias Kraus
 
-use crate::pb::{self, POD};
+use crate::marker::ShmSend;
+use crate::pb;
 use crate::sb;
 use crate::testing::RouDiEnvironment;
 use crate::Runtime;
@@ -14,7 +15,7 @@ struct Counter {
     counter: u32,
 }
 
-unsafe impl POD for Counter {}
+unsafe impl ShmSend for Counter {}
 
 #[test]
 fn basic_pub_sub() -> Result<()> {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the Rust coding style and is formatted with `rustfmt`
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#42 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

This PR renames the `POD` marker trait to `ShmSend` since it fulfills a similar purpose to `Send` but instead to mark data types to be transferred across thread boundaries it marks data types to be transferred across process boundaries.

Furthermore, there are additional impls for `ShmSend`.

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes #27
