### PR TITLE
Iox 1 use maybe uninit for sample

### DIFF
--- a/examples/publisher_allocate_uninitialized.rs
+++ b/examples/publisher_allocate_uninitialized.rs
@@ -11,7 +11,6 @@ use std::thread;
 use std::time::Duration;
 
 #[repr(C)]
-#[derive(Default)]
 struct Counter {
     counter: u32,
 }
@@ -25,8 +24,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut counter = 0u32;
     loop {
-        let mut sample = publisher.allocate_sample()?;
-        sample.counter = counter;
+        let mut sample = publisher.allocate_sample_uninitialized()?;
+        let sample = unsafe {
+            (*sample.as_mut_ptr()).counter = counter;
+            sample.assume_init()
+        };
         publisher.publish(sample);
 
         println!("Sending: {}", counter);

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: © Contributors to the iceoryx-rs project
 // SPDX-FileContributor: Mathias Kraus
 
+use std::mem::MaybeUninit;
+
 /// # Safety
 ///
 /// This is a marker trait for types that can be transferred via shared memory.
@@ -40,6 +42,8 @@ unsafe impl<T: ShmSend, const N: usize> ShmSend for [T; N] {}
 unsafe impl<T: ShmSend> ShmSend for Option<T> {}
 
 unsafe impl<T: ShmSend, E: ShmSend> ShmSend for Result<T, E> {}
+
+unsafe impl<T: ShmSend> ShmSend for MaybeUninit<T> {}
 
 // TODO create macro to impl ShmSend for tuples
 unsafe impl<T1, T2> ShmSend for (T1, T2)

--- a/src/pb/mod.rs
+++ b/src/pb/mod.rs
@@ -10,3 +10,5 @@ mod sample;
 pub use publisher::{InactivePublisher, Publisher, PublisherBuilder};
 
 use publisher_options::PublisherOptions;
+
+pub use sample::SampleMut;

--- a/src/pb/sample.rs
+++ b/src/pb/sample.rs
@@ -5,6 +5,7 @@
 use super::Publisher;
 use crate::marker::ShmSend;
 
+use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
 
 pub struct SampleMut<'a, T: ShmSend> {
@@ -28,8 +29,25 @@ impl<'a, T: ShmSend> DerefMut for SampleMut<'a, T> {
 
 impl<'a, T: ShmSend> Drop for SampleMut<'a, T> {
     fn drop(&mut self) {
-        if let Some(chunk) = self.data.take() {
-            self.service.release_chunk(chunk);
+        if let Some(data) = self.data.take() {
+            self.service.release_chunk(data);
+        }
+    }
+}
+
+impl<'a, T: ShmSend> SampleMut<'a, MaybeUninit<T>> {
+    pub unsafe fn assume_init(mut self) -> SampleMut<'a, T> {
+        let data = self.data.take().unwrap();
+
+        // TDDO use this once 'new_uninit' is stabilized
+        // 'let data = Box::assume_init(data);' or just 'let data = data.assume_init();'
+        // until then, the transmute is not nice but safe since MaybeUninit has the same layout as the inner type
+        let data = std::mem::transmute::<Box<MaybeUninit<T>>, Box<T>>(data);
+
+        SampleMut {
+            data: Some(data),
+            // the transmute is not nice but save since MaybeUninit has the same layout as the inner type
+            service: std::mem::transmute::<&Publisher<MaybeUninit<T>>, &Publisher<T>>(self.service),
         }
     }
 }

--- a/src/tests/basic_pub_sub.rs
+++ b/src/tests/basic_pub_sub.rs
@@ -11,6 +11,7 @@ use crate::Runtime;
 use anyhow::{anyhow, Result};
 
 #[repr(C)]
+#[derive(Default)]
 struct Counter {
     counter: u32,
 }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the Rust coding style and is formatted with `rustfmt`
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#42 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR enforces that a `SampleMut<T>` is always initialized by adding `Default` as trait bound for `T`. In case this restriction is not desired, a new API call for `SampleMut<MaybeUninit<T>>` is added.

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes #1
