### PR TITLE
Add a reference-counted version of `SampleMut`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,9 @@ pub use subscriber::SubscriberBuilder;
 mod sample_mut;
 pub use sample_mut::SampleMut;
 
+mod sample_mut_arc;
+pub use sample_mut_arc::SampleMutArc;
+
 mod sample;
 pub use sample::Sample;
 pub use sample::SampleReceiver;

--- a/src/sample_mut_arc.rs
+++ b/src/sample_mut_arc.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © Contributors to the iceoryx-rs project
+// SPDX-FileContributor: Mathias Kraus
+
+use super::Publisher;
+use crate::marker::ShmSend;
+
+use std::mem::MaybeUninit;
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+
+/// An owned, reference-counted mutable sample owned by a single publisher
+pub struct SampleMutArc<T: ShmSend + ?Sized> {
+    pub(super) data: Option<Box<T>>,
+    pub(super) publisher: Arc<Publisher<T>>,
+}
+
+impl<T: ShmSend + ?Sized> Deref for SampleMutArc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        // this is safe since only `drop` and `Publisher::send` will take the `Option`
+        unsafe { self.data.as_ref().unwrap_unchecked() }
+    }
+}
+
+impl<T: ShmSend + ?Sized> DerefMut for SampleMutArc<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // this is safe since only `drop` and `Publisher::send` will take the `Option`
+        unsafe { self.data.as_mut().unwrap_unchecked() }
+    }
+}
+
+impl<T: ShmSend + ?Sized> Drop for SampleMutArc<T> {
+    fn drop(&mut self) {
+        if let Some(data) = self.data.take() {
+            self.publisher.release_chunk(data);
+        }
+    }
+}
+
+impl<T: ShmSend> SampleMutArc<MaybeUninit<T>> {
+    /// Extracts the value of `MaybeUninit<T>` container and labels the sample as initialized
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `MaybeUninit<T>` really is initialized. Calling this when
+    /// the content is not fully initialized causes immediate undefined behavior.
+    pub unsafe fn assume_init(mut self) -> SampleMutArc<T> {
+        let data = self.data.take().unwrap();
+
+        // TDDO use this once 'new_uninit' is stabilized
+        // 'let data = Box::assume_init(data);' or just 'let data = data.assume_init();'
+        // until then, the transmute is not nice but safe since MaybeUninit has the same layout as the inner type
+        let data = std::mem::transmute::<Box<MaybeUninit<T>>, Box<T>>(data);
+
+        SampleMutArc {
+            data: Some(data),
+            // the transmute is not nice but safe since MaybeUninit has the same layout as the inner type
+            publisher: std::mem::transmute::<Arc<Publisher<MaybeUninit<T>>>, Arc<Publisher<T>>>(
+                self.publisher.clone(),
+            ),
+        }
+    }
+}
+
+impl<T: ShmSend> SampleMutArc<[MaybeUninit<T>]> {
+    /// Extracts the value of `MaybeUninit<T>` container and labels the sample as initialized
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `MaybeUninit<T>` really is initialized. Calling this when
+    /// the content is not fully initialized causes immediate undefined behavior.
+    pub unsafe fn assume_init(mut self) -> SampleMutArc<[T]> {
+        let data = self.data.take().unwrap();
+
+        // TDDO use this once 'new_uninit' is stabilized
+        // 'let data = Box::assume_init(data);' or just 'let data = data.assume_init();'
+        // until then, the transmute is not nice but safe since MaybeUninit has the same layout as the inner type
+        let data = std::mem::transmute::<Box<[MaybeUninit<T>]>, Box<[T]>>(data);
+
+        SampleMutArc {
+            data: Some(data),
+            // the transmute is not nice but safe since MaybeUninit has the same layout as the inner type
+            publisher: std::mem::transmute::<Arc<Publisher<[MaybeUninit<T>]>>, Arc<Publisher<[T]>>>(
+                self.publisher.clone(),
+            ),
+        }
+    }
+}
+
+impl SampleMutArc<[MaybeUninit<u8>]> {
+    /// Get a mutable slice to the elements
+    ///
+    /// # Safety
+    ///
+    /// It is safe to write to the slice but reading is undefined behaviour.
+    /// The main purpose of this method is to be used in combination with the `BufMut` trait of the
+    /// [bytes](https://crates.io/crates/bytes) crate.
+    pub unsafe fn slice_assume_init_mut(&mut self) -> &mut [u8] {
+        // TODO check if `MaybeUninit::slice_assume_init_mut` can be used once it is stabilized;
+        // it might not be possible since current documentation labels the usage as undefined behavior
+        // without restricting it to read access
+        std::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(
+            // this is safe since only `drop` and `Publisher::send` will take the `Option`
+            self.data.as_mut().unwrap_unchecked(),
+        )
+    }
+
+    /// Get a mutable reference to an uninitialized T
+    ///
+    /// If the size and alignment of T do not match with the alignment of the underlying buffer, None is returned.
+    pub fn try_as_uninit<T: ShmSend>(&mut self) -> Option<&mut MaybeUninit<T>> {
+        unsafe {
+            let data = self.data.as_mut().unwrap_unchecked();
+            let chunk_header =
+                ffi::ChunkHeader::from_user_payload(&*(data.as_ptr())).unwrap_unchecked();
+            let payload_size = chunk_header.get_user_payload_size() as usize;
+            let payload_alignment = chunk_header.get_user_payload_alignment() as usize;
+
+            if payload_size >= std::mem::size_of::<T>()
+                && payload_alignment >= std::mem::align_of::<T>()
+            {
+                Some(
+                    &mut *(std::mem::transmute::<*mut MaybeUninit<u8>, *mut MaybeUninit<T>>(
+                        data.as_mut_ptr(),
+                    )),
+                )
+            } else {
+                None
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allows to create owned samples when the publisher is reference-counted.

_Note:_ This is only a first draft to request feedback. I'm happy to polish this PR if this change is desired.

## Pre-Review Checklist for the PR Author

1. [x] Code follows the Rust coding style and is formatted with `rustfmt`
1. [ ] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [ ] Commits messages are according to this [guideline][commit-guidelines]
    - [ ] Commit messages have the issue ID (`iox-#42 commit text`)
    - [ ] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [ ] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [ ] Relevant issues are linked
1. [ ] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes **TBD**
